### PR TITLE
fixed build error due to removed support of cmake < 3.5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@ impl Build {
             .configure_arg("-DENABLE_DRAFTS=OFF")
             .configure_arg("-DBUILD_STATIC=1")
             .configure_arg("-DENABLE_RADIX_TREE=1")
-            .configure_arg("-DBUILD_SHARED=0");
+            .configure_arg("-DBUILD_SHARED=0")
+            .configure_arg("-DCMAKE_POLICY_VERSION_MINIMUM=3.5");
 
         match env::consts::ARCH {
             "x86_64" | "aarch64" => {


### PR DESCRIPTION
Error was:

```bash
--- stderr
  CMake Warning (dev) at CMakeLists.txt:2 (project):
    cmake_minimum_required() should be called prior to this top-level project()
    call.  Please see the cmake-commands(7) manual for usage documentation of
    both commands.
  This warning is for project developers.  Use -Wno-dev to suppress it.

  CMake Error at CMakeLists.txt:5 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.



  thread 'main' panicked at /Users/eliascroze/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cmake-0.1.54/src/lib.rs:1119:5:

  command did not execute successfully, got: exit status: 1

  build script failed, must exit now

```