### PR TITLE
feat: vendor ZMQ_TCP_MAX_PACING_RATE libzmq option

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor"]
 	path = vendor
-	url = https://github.com/zeromq/libzmq
-    branch = v4.3.5
+	url = git@github.com:vibe-ad/libzmq
+	branch = ts/feat/tcp-max-pacing-rate

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor"]
 	path = vendor
-	url = git@github.com:vibe-ad/libzmq
+	url = https://github.com/vibe-ad/libzmq
 	branch = ts/feat/tcp-max-pacing-rate


### PR DESCRIPTION
## Summary

Vendors vibe-ad/libzmq@e4688de5 which adds a `ZMQ_TCP_MAX_PACING_RATE` socket option (int, bytes/sec, 0 = unpaced). It mirrors `ZMQ_TCP_MAXRT` plumbing and applies `SO_MAX_PACING_RATE` to every connected and accepted TCP fd of the socket, so the fq qdisc spreads queue drains losslessly under the EC2 ENA bw_out token bucket. Linux-only, no-op elsewhere.

- repoint the vendor submodule from zeromq/libzmq to the vibe-ad fork (based on v4.3.5)